### PR TITLE
Image for city

### DIFF
--- a/app/controllers/api/v1/weather_controller.rb
+++ b/app/controllers/api/v1/weather_controller.rb
@@ -5,6 +5,11 @@
     render json: ForecastSerializer.new(@results)
   end
 
+  def image
+    @image = ImageFacade.find_image(strong_params[:location])
+    render json: ImageSerializer.new(@image)
+  end
+
 
 private
 

--- a/app/facades/image_facade.rb
+++ b/app/facades/image_facade.rb
@@ -1,0 +1,7 @@
+class ImageFacade
+
+  def self.find_image(city)
+    images = ImageService.find_image(city)
+    Image.new(images, city)
+  end
+end

--- a/app/poros/image.rb
+++ b/app/poros/image.rb
@@ -1,0 +1,18 @@
+class Image
+ attr_reader :id, :location, :image_url, :credit
+  def initialize(data, location)
+    @location = location
+    @image_url = data[:photos][0][:url]
+    @credit = format_credit(data[:photos][0])
+  end
+
+  def format_credit(info)
+    {
+      source: 'pexels.com/api',
+      author: info[:photographer],
+      logo: 'https://theme.zdassets.com/theme_assets/9028340/1e73e5cb95b89f1dce8b59c5236ca1fc28c7113b.png'
+
+    }
+  end
+
+end

--- a/app/serializers/image_serializer.rb
+++ b/app/serializers/image_serializer.rb
@@ -1,0 +1,3 @@
+class ImageSerializer < BaseSerializer
+  attributes :credit, :image_url, :location
+end

--- a/app/services/image_service.rb
+++ b/app/services/image_service.rb
@@ -1,0 +1,13 @@
+class ImageService
+  def self.conn
+    Faraday.new("https://api.pexels.com") do |conn|
+      conn.headers[:authorization] = ENV.fetch('PEXEL_API')
+    end
+  end
+  def self.find_image(city)
+    response = conn.get('/v1/search') do |f|
+      f.params[:query] = "City of #{city}"
+    end
+    JSON.parse(response.body, symbolize_names: true)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,8 @@ Rails.application.routes.draw do
 namespace :api do
   namespace :v1 do
     get '/forecast', to: 'weather#current'
+    get '/backgrounds', to: 'weather#image'
   end
 end
 end
+ 

--- a/spec/facades/image_facade_spec.rb
+++ b/spec/facades/image_facade_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe ImageFacade do
+  context 'class methods' do
+    it 'returns a hash of images by city' do
+      image = ImageFacade.find_image('chicago,il')
+
+      expect(image.credit).to be_a(Hash)
+      expect(image.credit).to have_key(:source)
+      expect(image.credit[:source]).to be_a(String)
+
+      expect(image.credit).to have_key(:author)
+      expect(image.credit[:author]).to be_a(String)
+
+      expect(image.credit).to have_key(:logo)
+      expect(image.credit[:logo]).to be_a(String)
+
+      expect(image.image_url).to be_a(String)
+
+      expect(image.location).to eq('chicago,il')
+
+    end
+  end
+end

--- a/spec/fixtures/image_response.json
+++ b/spec/fixtures/image_response.json
@@ -1,0 +1,308 @@
+{
+    "page": 1,
+    "per_page": 15,
+    "photos": [
+        {
+            "id": 3751006,
+            "width": 5399,
+            "height": 8701,
+            "url": "https://www.pexels.com/photo/the-denver-post-office-and-federal-court-house-3751006/",
+            "photographer": "Colin Lloyd",
+            "photographer_url": "https://www.pexels.com/@colin-lloyd-2120291",
+            "photographer_id": 2120291,
+            "src": {
+                "original": "https://images.pexels.com/photos/3751006/pexels-photo-3751006.jpeg",
+                "large2x": "https://images.pexels.com/photos/3751006/pexels-photo-3751006.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940",
+                "large": "https://images.pexels.com/photos/3751006/pexels-photo-3751006.jpeg?auto=compress&cs=tinysrgb&h=650&w=940",
+                "medium": "https://images.pexels.com/photos/3751006/pexels-photo-3751006.jpeg?auto=compress&cs=tinysrgb&h=350",
+                "small": "https://images.pexels.com/photos/3751006/pexels-photo-3751006.jpeg?auto=compress&cs=tinysrgb&h=130",
+                "portrait": "https://images.pexels.com/photos/3751006/pexels-photo-3751006.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=1200&w=800",
+                "landscape": "https://images.pexels.com/photos/3751006/pexels-photo-3751006.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=627&w=1200",
+                "tiny": "https://images.pexels.com/photos/3751006/pexels-photo-3751006.jpeg?auto=compress&cs=tinysrgb&dpr=1&fit=crop&h=200&w=280"
+            },
+            "liked": false
+        },
+        {
+            "id": 3751009,
+            "width": 3322,
+            "height": 4983,
+            "url": "https://www.pexels.com/photo/brown-concrete-building-during-night-time-3751009/",
+            "photographer": "Colin Lloyd",
+            "photographer_url": "https://www.pexels.com/@colin-lloyd-2120291",
+            "photographer_id": 2120291,
+            "src": {
+                "original": "https://images.pexels.com/photos/3751009/pexels-photo-3751009.jpeg",
+                "large2x": "https://images.pexels.com/photos/3751009/pexels-photo-3751009.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940",
+                "large": "https://images.pexels.com/photos/3751009/pexels-photo-3751009.jpeg?auto=compress&cs=tinysrgb&h=650&w=940",
+                "medium": "https://images.pexels.com/photos/3751009/pexels-photo-3751009.jpeg?auto=compress&cs=tinysrgb&h=350",
+                "small": "https://images.pexels.com/photos/3751009/pexels-photo-3751009.jpeg?auto=compress&cs=tinysrgb&h=130",
+                "portrait": "https://images.pexels.com/photos/3751009/pexels-photo-3751009.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=1200&w=800",
+                "landscape": "https://images.pexels.com/photos/3751009/pexels-photo-3751009.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=627&w=1200",
+                "tiny": "https://images.pexels.com/photos/3751009/pexels-photo-3751009.jpeg?auto=compress&cs=tinysrgb&dpr=1&fit=crop&h=200&w=280"
+            },
+            "liked": false
+        },
+        {
+            "id": 3751010,
+            "width": 3712,
+            "height": 5568,
+            "url": "https://www.pexels.com/photo/red-and-white-concrete-building-during-night-time-3751010/",
+            "photographer": "Colin Lloyd",
+            "photographer_url": "https://www.pexels.com/@colin-lloyd-2120291",
+            "photographer_id": 2120291,
+            "src": {
+                "original": "https://images.pexels.com/photos/3751010/pexels-photo-3751010.jpeg",
+                "large2x": "https://images.pexels.com/photos/3751010/pexels-photo-3751010.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940",
+                "large": "https://images.pexels.com/photos/3751010/pexels-photo-3751010.jpeg?auto=compress&cs=tinysrgb&h=650&w=940",
+                "medium": "https://images.pexels.com/photos/3751010/pexels-photo-3751010.jpeg?auto=compress&cs=tinysrgb&h=350",
+                "small": "https://images.pexels.com/photos/3751010/pexels-photo-3751010.jpeg?auto=compress&cs=tinysrgb&h=130",
+                "portrait": "https://images.pexels.com/photos/3751010/pexels-photo-3751010.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=1200&w=800",
+                "landscape": "https://images.pexels.com/photos/3751010/pexels-photo-3751010.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=627&w=1200",
+                "tiny": "https://images.pexels.com/photos/3751010/pexels-photo-3751010.jpeg?auto=compress&cs=tinysrgb&dpr=1&fit=crop&h=200&w=280"
+            },
+            "liked": false
+        },
+        {
+            "id": 2500159,
+            "width": 3448,
+            "height": 4592,
+            "url": "https://www.pexels.com/photo/photo-of-man-in-hoodie-sitting-on-concrete-slab-in-view-of-high-rise-building-under-sky-2500159/",
+            "photographer": "Aidan Roof",
+            "photographer_url": "https://www.pexels.com/@aidan-roof-1271136",
+            "photographer_id": 1271136,
+            "src": {
+                "original": "https://images.pexels.com/photos/2500159/pexels-photo-2500159.png",
+                "large2x": "https://images.pexels.com/photos/2500159/pexels-photo-2500159.png?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940",
+                "large": "https://images.pexels.com/photos/2500159/pexels-photo-2500159.png?auto=compress&cs=tinysrgb&h=650&w=940",
+                "medium": "https://images.pexels.com/photos/2500159/pexels-photo-2500159.png?auto=compress&cs=tinysrgb&h=350",
+                "small": "https://images.pexels.com/photos/2500159/pexels-photo-2500159.png?auto=compress&cs=tinysrgb&h=130",
+                "portrait": "https://images.pexels.com/photos/2500159/pexels-photo-2500159.png?auto=compress&cs=tinysrgb&fit=crop&h=1200&w=800",
+                "landscape": "https://images.pexels.com/photos/2500159/pexels-photo-2500159.png?auto=compress&cs=tinysrgb&fit=crop&h=627&w=1200",
+                "tiny": "https://images.pexels.com/photos/2500159/pexels-photo-2500159.png?auto=compress&cs=tinysrgb&dpr=1&fit=crop&h=200&w=280"
+            },
+            "liked": false
+        },
+        {
+            "id": 3751008,
+            "width": 3712,
+            "height": 5568,
+            "url": "https://www.pexels.com/photo/people-walking-on-street-3751008/",
+            "photographer": "Colin Lloyd",
+            "photographer_url": "https://www.pexels.com/@colin-lloyd-2120291",
+            "photographer_id": 2120291,
+            "src": {
+                "original": "https://images.pexels.com/photos/3751008/pexels-photo-3751008.jpeg",
+                "large2x": "https://images.pexels.com/photos/3751008/pexels-photo-3751008.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940",
+                "large": "https://images.pexels.com/photos/3751008/pexels-photo-3751008.jpeg?auto=compress&cs=tinysrgb&h=650&w=940",
+                "medium": "https://images.pexels.com/photos/3751008/pexels-photo-3751008.jpeg?auto=compress&cs=tinysrgb&h=350",
+                "small": "https://images.pexels.com/photos/3751008/pexels-photo-3751008.jpeg?auto=compress&cs=tinysrgb&h=130",
+                "portrait": "https://images.pexels.com/photos/3751008/pexels-photo-3751008.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=1200&w=800",
+                "landscape": "https://images.pexels.com/photos/3751008/pexels-photo-3751008.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=627&w=1200",
+                "tiny": "https://images.pexels.com/photos/3751008/pexels-photo-3751008.jpeg?auto=compress&cs=tinysrgb&dpr=1&fit=crop&h=200&w=280"
+            },
+            "liked": false
+        },
+        {
+            "id": 5627275,
+            "width": 4160,
+            "height": 6240,
+            "url": "https://www.pexels.com/photo/old-brooklyn-bridge-under-white-sky-at-sunset-5627275/",
+            "photographer": "Bryant's Juarez",
+            "photographer_url": "https://www.pexels.com/@bryant-s-juarez-3130904",
+            "photographer_id": 3130904,
+            "src": {
+                "original": "https://images.pexels.com/photos/5627275/pexels-photo-5627275.jpeg",
+                "large2x": "https://images.pexels.com/photos/5627275/pexels-photo-5627275.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940",
+                "large": "https://images.pexels.com/photos/5627275/pexels-photo-5627275.jpeg?auto=compress&cs=tinysrgb&h=650&w=940",
+                "medium": "https://images.pexels.com/photos/5627275/pexels-photo-5627275.jpeg?auto=compress&cs=tinysrgb&h=350",
+                "small": "https://images.pexels.com/photos/5627275/pexels-photo-5627275.jpeg?auto=compress&cs=tinysrgb&h=130",
+                "portrait": "https://images.pexels.com/photos/5627275/pexels-photo-5627275.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=1200&w=800",
+                "landscape": "https://images.pexels.com/photos/5627275/pexels-photo-5627275.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=627&w=1200",
+                "tiny": "https://images.pexels.com/photos/5627275/pexels-photo-5627275.jpeg?auto=compress&cs=tinysrgb&dpr=1&fit=crop&h=200&w=280"
+            },
+            "liked": false
+        },
+        {
+            "id": 5603829,
+            "width": 4000,
+            "height": 6000,
+            "url": "https://www.pexels.com/photo/picturesque-sunset-sky-over-city-5603829/",
+            "photographer": "Artem Saranin",
+            "photographer_url": "https://www.pexels.com/@arts",
+            "photographer_id": 359504,
+            "src": {
+                "original": "https://images.pexels.com/photos/5603829/pexels-photo-5603829.jpeg",
+                "large2x": "https://images.pexels.com/photos/5603829/pexels-photo-5603829.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940",
+                "large": "https://images.pexels.com/photos/5603829/pexels-photo-5603829.jpeg?auto=compress&cs=tinysrgb&h=650&w=940",
+                "medium": "https://images.pexels.com/photos/5603829/pexels-photo-5603829.jpeg?auto=compress&cs=tinysrgb&h=350",
+                "small": "https://images.pexels.com/photos/5603829/pexels-photo-5603829.jpeg?auto=compress&cs=tinysrgb&h=130",
+                "portrait": "https://images.pexels.com/photos/5603829/pexels-photo-5603829.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=1200&w=800",
+                "landscape": "https://images.pexels.com/photos/5603829/pexels-photo-5603829.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=627&w=1200",
+                "tiny": "https://images.pexels.com/photos/5603829/pexels-photo-5603829.jpeg?auto=compress&cs=tinysrgb&dpr=1&fit=crop&h=200&w=280"
+            },
+            "liked": false
+        },
+        {
+            "id": 5137445,
+            "width": 5024,
+            "height": 5078,
+            "url": "https://www.pexels.com/photo/lonely-brick-church-in-aged-city-5137445/",
+            "photographer": "Alex Kozlov",
+            "photographer_url": "https://www.pexels.com/@alex-kozlov-3442124",
+            "photographer_id": 3442124,
+            "src": {
+                "original": "https://images.pexels.com/photos/5137445/pexels-photo-5137445.jpeg",
+                "large2x": "https://images.pexels.com/photos/5137445/pexels-photo-5137445.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940",
+                "large": "https://images.pexels.com/photos/5137445/pexels-photo-5137445.jpeg?auto=compress&cs=tinysrgb&h=650&w=940",
+                "medium": "https://images.pexels.com/photos/5137445/pexels-photo-5137445.jpeg?auto=compress&cs=tinysrgb&h=350",
+                "small": "https://images.pexels.com/photos/5137445/pexels-photo-5137445.jpeg?auto=compress&cs=tinysrgb&h=130",
+                "portrait": "https://images.pexels.com/photos/5137445/pexels-photo-5137445.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=1200&w=800",
+                "landscape": "https://images.pexels.com/photos/5137445/pexels-photo-5137445.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=627&w=1200",
+                "tiny": "https://images.pexels.com/photos/5137445/pexels-photo-5137445.jpeg?auto=compress&cs=tinysrgb&dpr=1&fit=crop&h=200&w=280"
+            },
+            "liked": false
+        },
+        {
+            "id": 2269617,
+            "width": 4000,
+            "height": 6000,
+            "url": "https://www.pexels.com/photo/concrete-buildings-2269617/",
+            "photographer": "Spencer Selover",
+            "photographer_url": "https://www.pexels.com/@spencer-selover-142259",
+            "photographer_id": 142259,
+            "src": {
+                "original": "https://images.pexels.com/photos/2269617/pexels-photo-2269617.jpeg",
+                "large2x": "https://images.pexels.com/photos/2269617/pexels-photo-2269617.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940",
+                "large": "https://images.pexels.com/photos/2269617/pexels-photo-2269617.jpeg?auto=compress&cs=tinysrgb&h=650&w=940",
+                "medium": "https://images.pexels.com/photos/2269617/pexels-photo-2269617.jpeg?auto=compress&cs=tinysrgb&h=350",
+                "small": "https://images.pexels.com/photos/2269617/pexels-photo-2269617.jpeg?auto=compress&cs=tinysrgb&h=130",
+                "portrait": "https://images.pexels.com/photos/2269617/pexels-photo-2269617.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=1200&w=800",
+                "landscape": "https://images.pexels.com/photos/2269617/pexels-photo-2269617.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=627&w=1200",
+                "tiny": "https://images.pexels.com/photos/2269617/pexels-photo-2269617.jpeg?auto=compress&cs=tinysrgb&dpr=1&fit=crop&h=200&w=280"
+            },
+            "liked": false
+        },
+        {
+            "id": 5603830,
+            "width": 3935,
+            "height": 5902,
+            "url": "https://www.pexels.com/photo/crop-person-with-glass-ball-in-hand-5603830/",
+            "photographer": "Artem Saranin",
+            "photographer_url": "https://www.pexels.com/@arts",
+            "photographer_id": 359504,
+            "src": {
+                "original": "https://images.pexels.com/photos/5603830/pexels-photo-5603830.jpeg",
+                "large2x": "https://images.pexels.com/photos/5603830/pexels-photo-5603830.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940",
+                "large": "https://images.pexels.com/photos/5603830/pexels-photo-5603830.jpeg?auto=compress&cs=tinysrgb&h=650&w=940",
+                "medium": "https://images.pexels.com/photos/5603830/pexels-photo-5603830.jpeg?auto=compress&cs=tinysrgb&h=350",
+                "small": "https://images.pexels.com/photos/5603830/pexels-photo-5603830.jpeg?auto=compress&cs=tinysrgb&h=130",
+                "portrait": "https://images.pexels.com/photos/5603830/pexels-photo-5603830.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=1200&w=800",
+                "landscape": "https://images.pexels.com/photos/5603830/pexels-photo-5603830.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=627&w=1200",
+                "tiny": "https://images.pexels.com/photos/5603830/pexels-photo-5603830.jpeg?auto=compress&cs=tinysrgb&dpr=1&fit=crop&h=200&w=280"
+            },
+            "liked": false
+        },
+        {
+            "id": 2422861,
+            "width": 3448,
+            "height": 4592,
+            "url": "https://www.pexels.com/photo/curtain-wall-high-rise-building-beside-transmission-tower-2422861/",
+            "photographer": "Aidan Roof",
+            "photographer_url": "https://www.pexels.com/@aidan-roof-1271136",
+            "photographer_id": 1271136,
+            "src": {
+                "original": "https://images.pexels.com/photos/2422861/pexels-photo-2422861.png",
+                "large2x": "https://images.pexels.com/photos/2422861/pexels-photo-2422861.png?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940",
+                "large": "https://images.pexels.com/photos/2422861/pexels-photo-2422861.png?auto=compress&cs=tinysrgb&h=650&w=940",
+                "medium": "https://images.pexels.com/photos/2422861/pexels-photo-2422861.png?auto=compress&cs=tinysrgb&h=350",
+                "small": "https://images.pexels.com/photos/2422861/pexels-photo-2422861.png?auto=compress&cs=tinysrgb&h=130",
+                "portrait": "https://images.pexels.com/photos/2422861/pexels-photo-2422861.png?auto=compress&cs=tinysrgb&fit=crop&h=1200&w=800",
+                "landscape": "https://images.pexels.com/photos/2422861/pexels-photo-2422861.png?auto=compress&cs=tinysrgb&fit=crop&h=627&w=1200",
+                "tiny": "https://images.pexels.com/photos/2422861/pexels-photo-2422861.png?auto=compress&cs=tinysrgb&dpr=1&fit=crop&h=200&w=280"
+            },
+            "liked": false
+        },
+        {
+            "id": 5650644,
+            "width": 4496,
+            "height": 3000,
+            "url": "https://www.pexels.com/photo/colorful-carousel-placed-in-amusement-park-5650644/",
+            "photographer": "Tim Gouw",
+            "photographer_url": "https://www.pexels.com/@punttim",
+            "photographer_id": 8202,
+            "src": {
+                "original": "https://images.pexels.com/photos/5650644/pexels-photo-5650644.jpeg",
+                "large2x": "https://images.pexels.com/photos/5650644/pexels-photo-5650644.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940",
+                "large": "https://images.pexels.com/photos/5650644/pexels-photo-5650644.jpeg?auto=compress&cs=tinysrgb&h=650&w=940",
+                "medium": "https://images.pexels.com/photos/5650644/pexels-photo-5650644.jpeg?auto=compress&cs=tinysrgb&h=350",
+                "small": "https://images.pexels.com/photos/5650644/pexels-photo-5650644.jpeg?auto=compress&cs=tinysrgb&h=130",
+                "portrait": "https://images.pexels.com/photos/5650644/pexels-photo-5650644.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=1200&w=800",
+                "landscape": "https://images.pexels.com/photos/5650644/pexels-photo-5650644.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=627&w=1200",
+                "tiny": "https://images.pexels.com/photos/5650644/pexels-photo-5650644.jpeg?auto=compress&cs=tinysrgb&dpr=1&fit=crop&h=200&w=280"
+            },
+            "liked": false
+        },
+        {
+            "id": 5650642,
+            "width": 4496,
+            "height": 3000,
+            "url": "https://www.pexels.com/photo/ferris-wheel-against-blue-sky-5650642/",
+            "photographer": "Tim Gouw",
+            "photographer_url": "https://www.pexels.com/@punttim",
+            "photographer_id": 8202,
+            "src": {
+                "original": "https://images.pexels.com/photos/5650642/pexels-photo-5650642.jpeg",
+                "large2x": "https://images.pexels.com/photos/5650642/pexels-photo-5650642.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940",
+                "large": "https://images.pexels.com/photos/5650642/pexels-photo-5650642.jpeg?auto=compress&cs=tinysrgb&h=650&w=940",
+                "medium": "https://images.pexels.com/photos/5650642/pexels-photo-5650642.jpeg?auto=compress&cs=tinysrgb&h=350",
+                "small": "https://images.pexels.com/photos/5650642/pexels-photo-5650642.jpeg?auto=compress&cs=tinysrgb&h=130",
+                "portrait": "https://images.pexels.com/photos/5650642/pexels-photo-5650642.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=1200&w=800",
+                "landscape": "https://images.pexels.com/photos/5650642/pexels-photo-5650642.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=627&w=1200",
+                "tiny": "https://images.pexels.com/photos/5650642/pexels-photo-5650642.jpeg?auto=compress&cs=tinysrgb&dpr=1&fit=crop&h=200&w=280"
+            },
+            "liked": false
+        },
+        {
+            "id": 5597858,
+            "width": 3832,
+            "height": 5749,
+            "url": "https://www.pexels.com/photo/stylish-black-man-sitting-on-street-5597858/",
+            "photographer": "Amusan",
+            "photographer_url": "https://www.pexels.com/@picturesbyamusan",
+            "photographer_id": 3367119,
+            "src": {
+                "original": "https://images.pexels.com/photos/5597858/pexels-photo-5597858.jpeg",
+                "large2x": "https://images.pexels.com/photos/5597858/pexels-photo-5597858.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940",
+                "large": "https://images.pexels.com/photos/5597858/pexels-photo-5597858.jpeg?auto=compress&cs=tinysrgb&h=650&w=940",
+                "medium": "https://images.pexels.com/photos/5597858/pexels-photo-5597858.jpeg?auto=compress&cs=tinysrgb&h=350",
+                "small": "https://images.pexels.com/photos/5597858/pexels-photo-5597858.jpeg?auto=compress&cs=tinysrgb&h=130",
+                "portrait": "https://images.pexels.com/photos/5597858/pexels-photo-5597858.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=1200&w=800",
+                "landscape": "https://images.pexels.com/photos/5597858/pexels-photo-5597858.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=627&w=1200",
+                "tiny": "https://images.pexels.com/photos/5597858/pexels-photo-5597858.jpeg?auto=compress&cs=tinysrgb&dpr=1&fit=crop&h=200&w=280"
+            },
+            "liked": false
+        },
+        {
+            "id": 3184423,
+            "width": 4004,
+            "height": 6000,
+            "url": "https://www.pexels.com/photo/photo-of-people-holding-each-other-s-hands-3184423/",
+            "photographer": "fauxels",
+            "photographer_url": "https://www.pexels.com/@fauxels",
+            "photographer_id": 1281351,
+            "src": {
+                "original": "https://images.pexels.com/photos/3184423/pexels-photo-3184423.jpeg",
+                "large2x": "https://images.pexels.com/photos/3184423/pexels-photo-3184423.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940",
+                "large": "https://images.pexels.com/photos/3184423/pexels-photo-3184423.jpeg?auto=compress&cs=tinysrgb&h=650&w=940",
+                "medium": "https://images.pexels.com/photos/3184423/pexels-photo-3184423.jpeg?auto=compress&cs=tinysrgb&h=350",
+                "small": "https://images.pexels.com/photos/3184423/pexels-photo-3184423.jpeg?auto=compress&cs=tinysrgb&h=130",
+                "portrait": "https://images.pexels.com/photos/3184423/pexels-photo-3184423.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=1200&w=800",
+                "landscape": "https://images.pexels.com/photos/3184423/pexels-photo-3184423.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=627&w=1200",
+                "tiny": "https://images.pexels.com/photos/3184423/pexels-photo-3184423.jpeg?auto=compress&cs=tinysrgb&dpr=1&fit=crop&h=200&w=280"
+            },
+            "liked": false
+        }
+    ],
+    "total_results": 10000,
+    "next_page": "https://api.pexels.com/v1/search/?page=2&per_page=15&query=%22city+of+denver%2Cco%22"
+}

--- a/spec/poros/image_spec.rb
+++ b/spec/poros/image_spec.rb
@@ -1,0 +1,317 @@
+require 'rails_helper'
+
+RSpec.describe Image do
+  it 'exists' do
+    data = {:page=>1,
+ :per_page=>15,
+ :photos=>
+  [{:id=>5650631,
+    :width=>4181,
+    :height=>2790,
+    :url=>"https://www.pexels.com/photo/facade-of-stylish-building-with-inscription-5650631/",
+    :photographer=>"Tim Gouw",
+    :photographer_url=>"https://www.pexels.com/@punttim",
+    :photographer_id=>8202,
+    :src=>
+     {:original=>"https://images.pexels.com/photos/5650631/pexels-photo-5650631.jpeg",
+      :large2x=>"https://images.pexels.com/photos/5650631/pexels-photo-5650631.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940",
+      :large=>"https://images.pexels.com/photos/5650631/pexels-photo-5650631.jpeg?auto=compress&cs=tinysrgb&h=650&w=940",
+      :medium=>"https://images.pexels.com/photos/5650631/pexels-photo-5650631.jpeg?auto=compress&cs=tinysrgb&h=350",
+      :small=>"https://images.pexels.com/photos/5650631/pexels-photo-5650631.jpeg?auto=compress&cs=tinysrgb&h=130",
+      :portrait=>"https://images.pexels.com/photos/5650631/pexels-photo-5650631.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=1200&w=800",
+      :landscape=>
+       "https://images.pexels.com/photos/5650631/pexels-photo-5650631.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=627&w=1200",
+      :tiny=>
+       "https://images.pexels.com/photos/5650631/pexels-photo-5650631.jpeg?auto=compress&cs=tinysrgb&dpr=1&fit=crop&h=200&w=280"},
+    :liked=>false},
+   {:id=>3347244,
+    :width=>4016,
+    :height=>6016,
+    :url=>"https://www.pexels.com/photo/running-vehicles-on-road-3347244/",
+    :photographer=>"Bob Ward",
+    :photographer_url=>"https://www.pexels.com/@wardmedia",
+    :photographer_id=>368324,
+    :src=>
+     {:original=>"https://images.pexels.com/photos/3347244/pexels-photo-3347244.jpeg",
+      :large2x=>"https://images.pexels.com/photos/3347244/pexels-photo-3347244.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940",
+      :large=>"https://images.pexels.com/photos/3347244/pexels-photo-3347244.jpeg?auto=compress&cs=tinysrgb&h=650&w=940",
+      :medium=>"https://images.pexels.com/photos/3347244/pexels-photo-3347244.jpeg?auto=compress&cs=tinysrgb&h=350",
+      :small=>"https://images.pexels.com/photos/3347244/pexels-photo-3347244.jpeg?auto=compress&cs=tinysrgb&h=130",
+      :portrait=>"https://images.pexels.com/photos/3347244/pexels-photo-3347244.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=1200&w=800",
+      :landscape=>
+       "https://images.pexels.com/photos/3347244/pexels-photo-3347244.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=627&w=1200",
+      :tiny=>
+       "https://images.pexels.com/photos/3347244/pexels-photo-3347244.jpeg?auto=compress&cs=tinysrgb&dpr=1&fit=crop&h=200&w=280"},
+    :liked=>false},
+   {:id=>1769395,
+    :width=>2687,
+    :height=>3359,
+    :url=>"https://www.pexels.com/photo/aerial-photography-of-high-rise-buildings-1769395/",
+    :photographer=>"Alex Powell",
+    :photographer_url=>"https://www.pexels.com/@powella1190",
+    :photographer_id=>871185,
+    :src=>
+     {:original=>"https://images.pexels.com/photos/1769395/pexels-photo-1769395.jpeg",
+      :large2x=>"https://images.pexels.com/photos/1769395/pexels-photo-1769395.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940",
+      :large=>"https://images.pexels.com/photos/1769395/pexels-photo-1769395.jpeg?auto=compress&cs=tinysrgb&h=650&w=940",
+      :medium=>"https://images.pexels.com/photos/1769395/pexels-photo-1769395.jpeg?auto=compress&cs=tinysrgb&h=350",
+      :small=>"https://images.pexels.com/photos/1769395/pexels-photo-1769395.jpeg?auto=compress&cs=tinysrgb&h=130",
+      :portrait=>"https://images.pexels.com/photos/1769395/pexels-photo-1769395.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=1200&w=800",
+      :landscape=>
+       "https://images.pexels.com/photos/1769395/pexels-photo-1769395.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=627&w=1200",
+      :tiny=>
+       "https://images.pexels.com/photos/1769395/pexels-photo-1769395.jpeg?auto=compress&cs=tinysrgb&dpr=1&fit=crop&h=200&w=280"},
+    :liked=>false},
+   {:id=>1769339,
+    :width=>2795,
+    :height=>3494,
+    :url=>"https://www.pexels.com/photo/photography-of-high-rise-building-1769339/",
+    :photographer=>"Alex Powell",
+    :photographer_url=>"https://www.pexels.com/@powella1190",
+    :photographer_id=>871185,
+    :src=>
+     {:original=>"https://images.pexels.com/photos/1769339/pexels-photo-1769339.jpeg",
+      :large2x=>"https://images.pexels.com/photos/1769339/pexels-photo-1769339.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940",
+      :large=>"https://images.pexels.com/photos/1769339/pexels-photo-1769339.jpeg?auto=compress&cs=tinysrgb&h=650&w=940",
+      :medium=>"https://images.pexels.com/photos/1769339/pexels-photo-1769339.jpeg?auto=compress&cs=tinysrgb&h=350",
+      :small=>"https://images.pexels.com/photos/1769339/pexels-photo-1769339.jpeg?auto=compress&cs=tinysrgb&h=130",
+      :portrait=>"https://images.pexels.com/photos/1769339/pexels-photo-1769339.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=1200&w=800",
+      :landscape=>
+       "https://images.pexels.com/photos/1769339/pexels-photo-1769339.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=627&w=1200",
+      :tiny=>
+       "https://images.pexels.com/photos/1769339/pexels-photo-1769339.jpeg?auto=compress&cs=tinysrgb&dpr=1&fit=crop&h=200&w=280"},
+    :liked=>false},
+   {:id=>5362100,
+    :width=>3860,
+    :height=>5790,
+    :url=>"https://www.pexels.com/photo/green-city-park-located-at-bottom-of-modern-skyscrapers-5362100/",
+    :photographer=>"Ricardo Esquivel",
+    :photographer_url=>"https://www.pexels.com/@rickyrecap",
+    :photographer_id=>722822,
+    :src=>
+     {:original=>"https://images.pexels.com/photos/5362100/pexels-photo-5362100.jpeg",
+      :large2x=>"https://images.pexels.com/photos/5362100/pexels-photo-5362100.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940",
+      :large=>"https://images.pexels.com/photos/5362100/pexels-photo-5362100.jpeg?auto=compress&cs=tinysrgb&h=650&w=940",
+      :medium=>"https://images.pexels.com/photos/5362100/pexels-photo-5362100.jpeg?auto=compress&cs=tinysrgb&h=350",
+      :small=>"https://images.pexels.com/photos/5362100/pexels-photo-5362100.jpeg?auto=compress&cs=tinysrgb&h=130",
+      :portrait=>"https://images.pexels.com/photos/5362100/pexels-photo-5362100.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=1200&w=800",
+      :landscape=>
+       "https://images.pexels.com/photos/5362100/pexels-photo-5362100.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=627&w=1200",
+      :tiny=>
+       "https://images.pexels.com/photos/5362100/pexels-photo-5362100.jpeg?auto=compress&cs=tinysrgb&dpr=1&fit=crop&h=200&w=280"},
+    :liked=>false},
+   {:id=>373893,
+    :width=>5472,
+    :height=>3648,
+    :url=>"https://www.pexels.com/photo/architectural-design-architecture-buildings-city-373893/",
+    :photographer=>"Burst",
+    :photographer_url=>"https://www.pexels.com/@burst",
+    :photographer_id=>121963,
+    :src=>
+     {:original=>"https://images.pexels.com/photos/373893/pexels-photo-373893.jpeg",
+      :large2x=>"https://images.pexels.com/photos/373893/pexels-photo-373893.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940",
+      :large=>"https://images.pexels.com/photos/373893/pexels-photo-373893.jpeg?auto=compress&cs=tinysrgb&h=650&w=940",
+      :medium=>"https://images.pexels.com/photos/373893/pexels-photo-373893.jpeg?auto=compress&cs=tinysrgb&h=350",
+      :small=>"https://images.pexels.com/photos/373893/pexels-photo-373893.jpeg?auto=compress&cs=tinysrgb&h=130",
+      :portrait=>"https://images.pexels.com/photos/373893/pexels-photo-373893.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=1200&w=800",
+      :landscape=>"https://images.pexels.com/photos/373893/pexels-photo-373893.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=627&w=1200",
+      :tiny=>"https://images.pexels.com/photos/373893/pexels-photo-373893.jpeg?auto=compress&cs=tinysrgb&dpr=1&fit=crop&h=200&w=280"},
+    :liked=>false},
+   {:id=>1769342,
+    :width=>2725,
+    :height=>3406,
+    :url=>"https://www.pexels.com/photo/turned-on-building-lights-under-cloudy-sky-1769342/",
+    :photographer=>"Alex Powell",
+    :photographer_url=>"https://www.pexels.com/@powella1190",
+    :photographer_id=>871185,
+    :src=>
+     {:original=>"https://images.pexels.com/photos/1769342/pexels-photo-1769342.jpeg",
+      :large2x=>"https://images.pexels.com/photos/1769342/pexels-photo-1769342.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940",
+      :large=>"https://images.pexels.com/photos/1769342/pexels-photo-1769342.jpeg?auto=compress&cs=tinysrgb&h=650&w=940",
+      :medium=>"https://images.pexels.com/photos/1769342/pexels-photo-1769342.jpeg?auto=compress&cs=tinysrgb&h=350",
+      :small=>"https://images.pexels.com/photos/1769342/pexels-photo-1769342.jpeg?auto=compress&cs=tinysrgb&h=130",
+      :portrait=>"https://images.pexels.com/photos/1769342/pexels-photo-1769342.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=1200&w=800",
+      :landscape=>
+       "https://images.pexels.com/photos/1769342/pexels-photo-1769342.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=627&w=1200",
+      :tiny=>
+       "https://images.pexels.com/photos/1769342/pexels-photo-1769342.jpeg?auto=compress&cs=tinysrgb&dpr=1&fit=crop&h=200&w=280"},
+    :liked=>false},
+   {:id=>1563256,
+    :width=>2642,
+    :height=>3419,
+    :url=>"https://www.pexels.com/photo/person-walking-on-the-road-1563256/",
+    :photographer=>"Ricardo Esquivel",
+    :photographer_url=>"https://www.pexels.com/@rickyrecap",
+    :photographer_id=>722822,
+    :src=>
+     {:original=>"https://images.pexels.com/photos/1563256/pexels-photo-1563256.jpeg",
+      :large2x=>"https://images.pexels.com/photos/1563256/pexels-photo-1563256.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940",
+      :large=>"https://images.pexels.com/photos/1563256/pexels-photo-1563256.jpeg?auto=compress&cs=tinysrgb&h=650&w=940",
+      :medium=>"https://images.pexels.com/photos/1563256/pexels-photo-1563256.jpeg?auto=compress&cs=tinysrgb&h=350",
+      :small=>"https://images.pexels.com/photos/1563256/pexels-photo-1563256.jpeg?auto=compress&cs=tinysrgb&h=130",
+      :portrait=>"https://images.pexels.com/photos/1563256/pexels-photo-1563256.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=1200&w=800",
+      :landscape=>
+       "https://images.pexels.com/photos/1563256/pexels-photo-1563256.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=627&w=1200",
+      :tiny=>
+       "https://images.pexels.com/photos/1563256/pexels-photo-1563256.jpeg?auto=compress&cs=tinysrgb&dpr=1&fit=crop&h=200&w=280"},
+    :liked=>false},
+   {:id=>5362093,
+    :width=>5617,
+    :height=>3745,
+    :url=>"https://www.pexels.com/photo/modern-city-district-with-skyscrapers-near-green-lawn-5362093/",
+    :photographer=>"Ricardo Esquivel",
+    :photographer_url=>"https://www.pexels.com/@rickyrecap",
+    :photographer_id=>722822,
+    :src=>
+     {:original=>"https://images.pexels.com/photos/5362093/pexels-photo-5362093.jpeg",
+      :large2x=>"https://images.pexels.com/photos/5362093/pexels-photo-5362093.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940",
+      :large=>"https://images.pexels.com/photos/5362093/pexels-photo-5362093.jpeg?auto=compress&cs=tinysrgb&h=650&w=940",
+      :medium=>"https://images.pexels.com/photos/5362093/pexels-photo-5362093.jpeg?auto=compress&cs=tinysrgb&h=350",
+      :small=>"https://images.pexels.com/photos/5362093/pexels-photo-5362093.jpeg?auto=compress&cs=tinysrgb&h=130",
+      :portrait=>"https://images.pexels.com/photos/5362093/pexels-photo-5362093.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=1200&w=800",
+      :landscape=>
+       "https://images.pexels.com/photos/5362093/pexels-photo-5362093.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=627&w=1200",
+      :tiny=>
+       "https://images.pexels.com/photos/5362093/pexels-photo-5362093.jpeg?auto=compress&cs=tinysrgb&dpr=1&fit=crop&h=200&w=280"},
+    :liked=>false},
+   {:id=>1722183,
+    :width=>4000,
+    :height=>6000,
+    :url=>"https://www.pexels.com/photo/sears-tower-usa-1722183/",
+    :photographer=>"Cameron Casey",
+    :photographer_url=>"https://www.pexels.com/@camcasey",
+    :photographer_id=>455136,
+    :src=>
+     {:original=>"https://images.pexels.com/photos/1722183/pexels-photo-1722183.jpeg",
+      :large2x=>"https://images.pexels.com/photos/1722183/pexels-photo-1722183.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940",
+      :large=>"https://images.pexels.com/photos/1722183/pexels-photo-1722183.jpeg?auto=compress&cs=tinysrgb&h=650&w=940",
+      :medium=>"https://images.pexels.com/photos/1722183/pexels-photo-1722183.jpeg?auto=compress&cs=tinysrgb&h=350",
+      :small=>"https://images.pexels.com/photos/1722183/pexels-photo-1722183.jpeg?auto=compress&cs=tinysrgb&h=130",
+      :portrait=>"https://images.pexels.com/photos/1722183/pexels-photo-1722183.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=1200&w=800",
+      :landscape=>
+       "https://images.pexels.com/photos/1722183/pexels-photo-1722183.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=627&w=1200",
+      :tiny=>
+       "https://images.pexels.com/photos/1722183/pexels-photo-1722183.jpeg?auto=compress&cs=tinysrgb&dpr=1&fit=crop&h=200&w=280"},
+    :liked=>false},
+   {:id=>2362004,
+    :width=>5242,
+    :height=>6553,
+    :url=>"https://www.pexels.com/photo/aerial-photo-of-cityscape-at-night-2362004/",
+    :photographer=>"Benjamin Suter",
+    :photographer_url=>"https://www.pexels.com/@benjaminjsuter",
+    :photographer_id=>1166597,
+    :src=>
+     {:original=>"https://images.pexels.com/photos/2362004/pexels-photo-2362004.jpeg",
+      :large2x=>"https://images.pexels.com/photos/2362004/pexels-photo-2362004.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940",
+      :large=>"https://images.pexels.com/photos/2362004/pexels-photo-2362004.jpeg?auto=compress&cs=tinysrgb&h=650&w=940",
+      :medium=>"https://images.pexels.com/photos/2362004/pexels-photo-2362004.jpeg?auto=compress&cs=tinysrgb&h=350",
+      :small=>"https://images.pexels.com/photos/2362004/pexels-photo-2362004.jpeg?auto=compress&cs=tinysrgb&h=130",
+      :portrait=>"https://images.pexels.com/photos/2362004/pexels-photo-2362004.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=1200&w=800",
+      :landscape=>
+       "https://images.pexels.com/photos/2362004/pexels-photo-2362004.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=627&w=1200",
+      :tiny=>
+       "https://images.pexels.com/photos/2362004/pexels-photo-2362004.jpeg?auto=compress&cs=tinysrgb&dpr=1&fit=crop&h=200&w=280"},
+    :liked=>false},
+   {:id=>3617460,
+    :width=>4000,
+    :height=>5000,
+    :url=>"https://www.pexels.com/photo/cars-on-road-between-high-rise-buildings-3617460/",
+    :photographer=>"Benjamin Suter",
+    :photographer_url=>"https://www.pexels.com/@benjaminjsuter",
+    :photographer_id=>1166597,
+    :src=>
+     {:original=>"https://images.pexels.com/photos/3617460/pexels-photo-3617460.jpeg",
+      :large2x=>"https://images.pexels.com/photos/3617460/pexels-photo-3617460.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940",
+      :large=>"https://images.pexels.com/photos/3617460/pexels-photo-3617460.jpeg?auto=compress&cs=tinysrgb&h=650&w=940",
+      :medium=>"https://images.pexels.com/photos/3617460/pexels-photo-3617460.jpeg?auto=compress&cs=tinysrgb&h=350",
+      :small=>"https://images.pexels.com/photos/3617460/pexels-photo-3617460.jpeg?auto=compress&cs=tinysrgb&h=130",
+      :portrait=>"https://images.pexels.com/photos/3617460/pexels-photo-3617460.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=1200&w=800",
+      :landscape=>
+       "https://images.pexels.com/photos/3617460/pexels-photo-3617460.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=627&w=1200",
+      :tiny=>
+       "https://images.pexels.com/photos/3617460/pexels-photo-3617460.jpeg?auto=compress&cs=tinysrgb&dpr=1&fit=crop&h=200&w=280"},
+    :liked=>false},
+   {:id=>1662159,
+    :width=>3769,
+    :height=>4711,
+    :url=>"https://www.pexels.com/photo/high-rise-building-1662159/",
+    :photographer=>"Ricardo Esquivel",
+    :photographer_url=>"https://www.pexels.com/@rickyrecap",
+    :photographer_id=>722822,
+    :src=>
+     {:original=>"https://images.pexels.com/photos/1662159/pexels-photo-1662159.jpeg",
+      :large2x=>"https://images.pexels.com/photos/1662159/pexels-photo-1662159.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940",
+      :large=>"https://images.pexels.com/photos/1662159/pexels-photo-1662159.jpeg?auto=compress&cs=tinysrgb&h=650&w=940",
+      :medium=>"https://images.pexels.com/photos/1662159/pexels-photo-1662159.jpeg?auto=compress&cs=tinysrgb&h=350",
+      :small=>"https://images.pexels.com/photos/1662159/pexels-photo-1662159.jpeg?auto=compress&cs=tinysrgb&h=130",
+      :portrait=>"https://images.pexels.com/photos/1662159/pexels-photo-1662159.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=1200&w=800",
+      :landscape=>
+       "https://images.pexels.com/photos/1662159/pexels-photo-1662159.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=627&w=1200",
+      :tiny=>
+       "https://images.pexels.com/photos/1662159/pexels-photo-1662159.jpeg?auto=compress&cs=tinysrgb&dpr=1&fit=crop&h=200&w=280"},
+    :liked=>false},
+   {:id=>2093323,
+    :width=>6000,
+    :height=>3376,
+    :url=>"https://www.pexels.com/photo/bird-s-eye-view-of-city-during-dawn-2093323/",
+    :photographer=>"Chait Goli",
+    :photographer_url=>"https://www.pexels.com/@chaitaastic",
+    :photographer_id=>876963,
+    :src=>
+     {:original=>"https://images.pexels.com/photos/2093323/pexels-photo-2093323.jpeg",
+      :large2x=>"https://images.pexels.com/photos/2093323/pexels-photo-2093323.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940",
+      :large=>"https://images.pexels.com/photos/2093323/pexels-photo-2093323.jpeg?auto=compress&cs=tinysrgb&h=650&w=940",
+      :medium=>"https://images.pexels.com/photos/2093323/pexels-photo-2093323.jpeg?auto=compress&cs=tinysrgb&h=350",
+      :small=>"https://images.pexels.com/photos/2093323/pexels-photo-2093323.jpeg?auto=compress&cs=tinysrgb&h=130",
+      :portrait=>"https://images.pexels.com/photos/2093323/pexels-photo-2093323.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=1200&w=800",
+      :landscape=>
+       "https://images.pexels.com/photos/2093323/pexels-photo-2093323.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=627&w=1200",
+      :tiny=>
+       "https://images.pexels.com/photos/2093323/pexels-photo-2093323.jpeg?auto=compress&cs=tinysrgb&dpr=1&fit=crop&h=200&w=280"},
+    :liked=>false},
+   {:id=>161963,
+    :width=>2740,
+    :height=>1859,
+    :url=>"https://www.pexels.com/photo/one-world-trade-center-under-cloudy-sky-during-daytime-161963/",
+    :photographer=>"Pixabay",
+    :photographer_url=>"https://www.pexels.com/@pixabay",
+    :photographer_id=>2659,
+    :src=>
+     {:original=>"https://images.pexels.com/photos/161963/chicago-illinois-skyline-skyscrapers-161963.jpeg",
+      :large2x=>
+       "https://images.pexels.com/photos/161963/chicago-illinois-skyline-skyscrapers-161963.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940",
+      :large=>
+       "https://images.pexels.com/photos/161963/chicago-illinois-skyline-skyscrapers-161963.jpeg?auto=compress&cs=tinysrgb&h=650&w=940",
+      :medium=>
+       "https://images.pexels.com/photos/161963/chicago-illinois-skyline-skyscrapers-161963.jpeg?auto=compress&cs=tinysrgb&h=350",
+      :small=>
+       "https://images.pexels.com/photos/161963/chicago-illinois-skyline-skyscrapers-161963.jpeg?auto=compress&cs=tinysrgb&h=130",
+      :portrait=>
+       "https://images.pexels.com/photos/161963/chicago-illinois-skyline-skyscrapers-161963.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=1200&w=800",
+      :landscape=>
+       "https://images.pexels.com/photos/161963/chicago-illinois-skyline-skyscrapers-161963.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=627&w=1200",
+      :tiny=>
+       "https://images.pexels.com/photos/161963/chicago-illinois-skyline-skyscrapers-161963.jpeg?auto=compress&cs=tinysrgb&dpr=1&fit=crop&h=200&w=280"},
+    :liked=>false}],
+ :total_results=>10000,
+ :next_page=>"https://api.pexels.com/v1/search/?page=2&per_page=15&query=city+of+chicago%2Cil"}
+    location = 'chicago,il'
+
+    image = Image.new(data, location)
+    expect(image.location).to eq(location)
+    expect(image.image_url).to be_a(String)
+    expect(image.credit).to be_a(Hash)
+
+    expect(image.credit).to have_key(:source)
+    expect(image.credit[:source]).to be_a(String)
+
+    expect(image.credit).to have_key(:author)
+    expect(image.credit[:author]).to be_a(String)
+
+    expect(image.credit).to have_key(:logo)
+    expect(image.credit[:logo]).to be_a(String)
+
+
+
+  end
+end

--- a/spec/requests/image_for_city_request_spec.rb
+++ b/spec/requests/image_for_city_request_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+describe 'Image for City' do
+  it 'can get appropriate image for city' do
+    request_params = {
+      location: 'denver,co'
+    }
+    get "/api/v1/backgrounds", params: request_params
+
+
+    expect(response).to be_successful
+    image = JSON.parse(response.body, symbolize_names: true)
+
+    expect(image).to have_key(:data)
+    expect(image[:data]).to be_a(Hash)
+
+    data = image[:data]
+    expect(data).to have_key(:id)
+    expect(data[:id]).to eq(nil)
+
+    expect(data).to have_key(:type)
+    expect(data[:type]).to eq('image')
+
+    expect(data).to have_key(:attributes)
+    expect(data[:attributes]).to be_a(Hash)
+
+    attributes = data[:attributes]
+    #FIGURE OUT HOW TO GET RID OF THIS!
+    expect(attributes).to have_key(:image_url)
+    expect(attributes[:image_url]).to be_a(String)
+
+    expect(attributes).to have_key(:location)
+    expect(attributes[:location]).to be_a(String)
+
+    expect(attributes).to have_key(:credit)
+    expect(attributes[:credit]).to be_a(Hash)
+
+    credit = attributes[:credit]
+    expect(credit).to have_key(:source)
+    expect(credit[:source]).to be_a(String)
+
+    expect(credit).to have_key(:author)
+    expect(credit[:author]).to be_a(String)
+
+    expect(credit).to have_key(:logo)
+    expect(credit[:logo]).to be_a(String)
+  end
+end

--- a/spec/services/image_service_spec.rb
+++ b/spec/services/image_service_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+describe ImageService do
+  context 'class methods' do
+    it 'returns images of chicago' do
+      data = 'chicago,il'
+      images = ImageService.find_image(data)
+
+      expect(images).to be_a(Hash)
+      expect(images[:photos]).to be_an(Array)
+      expect(images[:photos].count).to eq(15)
+
+      one_image = images[:photos][0]
+      expect(one_image).to have_key(:id)
+      expect(one_image[:id]).to be_an(Integer)
+
+      expect(one_image).to have_key(:width)
+      expect(one_image[:width]).to be_an(Integer)
+
+      expect(one_image).to have_key(:height)
+      expect(one_image[:height]).to be_an(Integer)
+
+      expect(one_image).to have_key(:url)
+      expect(one_image[:url]).to be_a(String)
+
+      expect(one_image).to have_key(:photographer)
+      expect(one_image[:photographer]).to be_a(String)
+
+      expect(one_image).to have_key(:photographer_url)
+      expect(one_image[:photographer_url]).to be_a(String)
+
+      expect(one_image).to have_key(:photographer_id)
+      expect(one_image[:photographer_id]).to be_an(Integer)
+
+      expect(one_image).to have_key(:src)
+      expect(one_image[:src]).to be_a(Hash)
+      expect(one_image).to have_key(:liked)
+      expect(one_image[:liked]).to eq(true).or eq(false)
+
+      source = one_image[:src]
+
+      expect(source).to have_key(:original)
+      expect(source[:original]).to be_a(String)
+
+      expect(source).to have_key(:large2x)
+      expect(source[:large2x]).to be_a(String)
+
+      expect(source).to have_key(:large)
+      expect(source[:large]).to be_a(String)
+
+      expect(source).to have_key(:medium)
+      expect(source[:medium]).to be_a(String)
+
+      expect(source).to have_key(:small)
+      expect(source[:small]).to be_a(String)
+
+      expect(source).to have_key(:portrait)
+      expect(source[:portrait]).to be_a(String)
+
+      expect(source).to have_key(:landscape)
+      expect(source[:landscape]).to be_a(String)
+
+      expect(source).to have_key(:tiny)
+      expect(source[:tiny]).to be_a(String)
+    end
+  end
+end


### PR DESCRIPTION
Adds the controller image action, that leads to an ImageFacade, which process an ImagePoro, which pulls from an ImageService as requested in the spec.

```json
status: 200
body:

{
  "data": {
    "type": "image",
    "id": null,
    "image": {
      "location": "denver,co",
      "image_url": "https://pixabay.com/get/54e6d4444f50a814f1dc8460962930761c38d6ed534c704c7c2878dd954dc451_640.jpg",
      "credit": {
        "source": "pixabay.com",
        "author": "quinntheislander",
        "logo": "https://pixabay.com/static/img/logo_square.png"
      }
    }
  }
}
```